### PR TITLE
Add OAuth Body Hash

### DIFF
--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -318,6 +318,7 @@ class Oauth1 implements SubscriberInterface
             'token'     => 'oauth_token',
             'verifier'  => 'oauth_verifier',
             'version'   => 'oauth_version'
+            'bodyhash'  => 'oauth_body_hash'
         ];
 
         foreach ($optionalParams as $optionName => $oauthName) {


### PR DESCRIPTION
add the oauth_body_hash authorization parameter to be added when signing the request.  This is needed for certain requests that want to verify the request body.

One specific example are LMS LTI service requests back to the LMS
